### PR TITLE
🐛 Update gradle spring boot version to fix CVE-2023-20873

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.5"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.4"
   kotlin("plugin.spring") version "1.8.10"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.4"
-  kotlin("plugin.spring") version "1.8.10"
+  kotlin("plugin.spring") version "1.8.21"
 }
 
 configurations {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.6"
   kotlin("plugin.spring") version "1.8.21"
 }
 


### PR DESCRIPTION
The security circleci job found vulnerabilities in the following libraries:

- org.springframework.boot:spring-boot-actuator-autoconfigure
- org.springframework:spring-core

Hopefully this will fix the problem!