### PR TITLE
Updated to latest beta of uk.gov.justice.hmpps.gradle-spring-boot - fixed owasp issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
   kotlin("jvm") version "1.8.21"
   id("io.ktor.plugin") version "2.3.0"
   id("org.owasp.dependencycheck") version "8.2.1"
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.2.0-beta"
 }
 
 group = "uk.gov.justice.digital.hmpps.hmppselectronicmonitoringdataplatformapi"


### PR DESCRIPTION
Confirm works locally by running `./gradlew dependencyCheckAnalyze --info`
Also check docker builds work - database container is not expected to start.