### PR TITLE
Fix/infinite device recursion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,13 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - ./db/data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
       - ./db/dev/databases.sql:/docker-entrypoint-initdb.d/1-dev-database.sql
       - ./db/dev/roles.sql:/docker-entrypoint-initdb.d/2-dev-roles.sql
 
 networks:
   hmpps:
   db-network:
+
+volumes:
+  db-data:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringdataplatformapi/model/Device.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppselectronicmonitoringdataplatformapi/model/Device.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppselectronicmonitoringdataplatformapi.mo
 import jakarta.persistence.*
 import org.springframework.format.annotation.DateTimeFormat
 import java.util.*
+import com.fasterxml.jackson.annotation.JsonIgnore
 
 @Entity
 @Table(name = "device")
@@ -23,6 +24,7 @@ data class Device(
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   val dateTagRemoved: Date? = Date(Long.MIN_VALUE),
 
+  @JsonIgnore
   @ManyToOne(cascade = [(CascadeType.REMOVE)], fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "device_wearer_id")
   val deviceWearer: DeviceWearer? = null


### PR DESCRIPTION

- Moves database volume to a Docker volume not the source tree
- Removes `deviceWearer` from the serialization of `Device`
    - This fixes the recursion in the API but may break other cases